### PR TITLE
feat: support `externalProtocols`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true
   }


### PR DESCRIPTION
Support new option and defaults to avoid externalizing unknown protocols without manual `inline` regex for each