### PR TITLE
fix: exclude nested `node_modules` from inline matcher

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ export function matches <T = any> (input: string, matchers: Matcher<T>[], ctx?: 
 export function toMatcher (pattern: string): RegExp
 export function toMatcher<T> (pattern: Matcher<T>): Matcher<T>
 export function toMatcher (pattern: any) {
-  return typeof pattern === 'string' ? new RegExp(`([\\/]|^)${pattern}([\\/]|$)`) : pattern
+  return typeof pattern === 'string' ? new RegExp(`([\\/]|^)${pattern}([\\/](?!node_modules)|$)`) : pattern
 }
 
 export function getType (id: string, fallback: ModuleType = 'commonjs'): ModuleType {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -13,4 +13,15 @@ describe('toMatcher', () => {
     const input = () => true
     expect(toMatcher(input)).toBe(input)
   })
+  it('does not match nested node_modules', () => {
+    const input = 'my-module'
+    expect(toMatcher(input).test('node_modules/my-module')).toBeTruthy()
+    expect(toMatcher(input).test('my-module')).toBeTruthy()
+    expect(
+      toMatcher(input).test('node_modules/my-module/index.js')
+    ).toBeTruthy()
+    expect(
+      toMatcher(input).test('node_modules/my-module/node_modules/other-module')
+    ).toBeFalsy()
+  })
 })


### PR DESCRIPTION
Previously, adding 'my-module' to the inline field would mean that the following would also match 😬

```
/private/tmp/project/node_modules/my-module/node_modules/other-module/lib/index.js
```