### PR TITLE
chore: add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "externality",
   "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unjs/externality"
+  },
   "license": "MIT",
   "sideEffects": false,
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,7 @@
 {
   "name": "externality",
   "version": "1.0.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/unjs/externality"
-  },
+  "repository": "unjs/externality"
   "license": "MIT",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
Hi,

this pull request adds the repository field to package.json, which will show nicely in the npm registry interface.

For give you more context, our internal scanner flags Nuxt as an issue because its has dependency on externality that doesn't clarify its source code location.

Let me know if I need to do extra steps to be able to merge.

Thanks.